### PR TITLE
Update adct ports

### DIFF
--- a/artioml-adct/adct-deployment.yaml
+++ b/artioml-adct/adct-deployment.yaml
@@ -20,7 +20,7 @@ spec:
       - image: artioml/adct
         name: adct
         ports:
-        - containerPort: 80
+        - containerPort: 8080
           name: adct-http
-        - containerPort: 443
+        - containerPort: 8443
           name: adct-https

--- a/artioml-adct/adct-http-configMap.yaml
+++ b/artioml-adct/adct-http-configMap.yaml
@@ -21,7 +21,7 @@ data:
         },
         "backend": {
           "serviceName": "adct",
-          "servicePort": 80,
+          "servicePort": 8080,
           "healthMonitors": [{
             "interval": 30,
             "protocol": "http",

--- a/artioml-adct/adct-https-configMap.yaml
+++ b/artioml-adct/adct-https-configMap.yaml
@@ -24,7 +24,7 @@ data:
         },
         "backend": {
           "serviceName": "adct",
-          "servicePort": 80,
+          "servicePort": 8080,
           "healthMonitors": [{
             "interval": 30,
             "protocol": "http",

--- a/artioml-adct/adct-services.yaml
+++ b/artioml-adct/adct-services.yaml
@@ -7,10 +7,10 @@ metadata:
 spec:
   ports:
     - name: http
-      port: 80
+      port: 8080
       protocol: TCP
     - name: https
-      port: 443
+      port: 8443
       protocol: TCP
   selector:
     app: adct


### PR DESCRIPTION
Hi Paolo,

I have changed the ports exposed by the adct container to 8080 (HTTP) and 8443 (HTTPS) to be able to run it as a non-root user.

Updated Dockerfile: https://github.com/ArtiomL/adct/blob/master/Dockerfile

Thanks!
